### PR TITLE
Update agegate.yml

### DIFF
--- a/_config/agegate.yml
+++ b/_config/agegate.yml
@@ -7,4 +7,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\Control\Director:
     properties:
       Middlewares:
-        AgeGateMiddleware: %$Moosylvania\AgeGate\Middlewares\AgeGateMiddleware
+        AgeGateMiddleware: '%$Moosylvania\AgeGate\Middlewares\AgeGateMiddleware'


### PR DESCRIPTION
results in The reserved indicator "%" cannot start a plain scalar; errors on newer versions without the quotes